### PR TITLE
refactor book apis

### DIFF
--- a/internal/book/book.go
+++ b/internal/book/book.go
@@ -1,6 +1,7 @@
 package book
 
 type Book struct {
+	ID          int
 	OwnerID     string
 	ISBN        string
 	Title       string
@@ -29,6 +30,7 @@ func (b *Book) AddBriefReview(review string) {
 }
 
 type BookInfo struct {
+	ID          int       `json:"id"`
 	ISBN        string    `json:"isbn"`
 	Title       string    `json:"title"`
 	Description string    `json:"description"`
@@ -39,6 +41,6 @@ type BookInfo struct {
 }
 
 type BookOwner struct {
-	OwnerID  string `json:"owner_id"`
+	ID       string `json:"owner_id"`
 	Username string `json:"username"`
 }

--- a/internal/book/delivery/handlers.go
+++ b/internal/book/delivery/handlers.go
@@ -2,6 +2,7 @@ package delivery
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/labstack/echo/v4"
 	"github.com/ngoctrng/bookz/internal/book"
@@ -45,9 +46,9 @@ func (h *Handler) Create(c echo.Context) error {
 }
 
 func (h *Handler) Get(c echo.Context) error {
-	isbn := c.Param("isbn")
+	id, _ := strconv.Atoi(c.Param("id"))
 
-	b, err := h.uc.Get(isbn)
+	b, err := h.uc.Get(id)
 	if err != nil || b == nil {
 		return echo.NewHTTPError(http.StatusNotFound, "book not found")
 	}
@@ -95,10 +96,10 @@ func (h *Handler) Update(c echo.Context) error {
 }
 
 func (h *Handler) Delete(c echo.Context) error {
-	isbn := c.Param("isbn")
+	id, _ := strconv.Atoi(c.Param("id"))
 	ownerID := c.Get("user_id").(string)
 
-	if err := h.uc.Delete(isbn, ownerID); err != nil {
+	if err := h.uc.Delete(id, ownerID); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 	}
 

--- a/internal/book/delivery/handlers_test.go
+++ b/internal/book/delivery/handlers_test.go
@@ -38,14 +38,14 @@ func TestCreateBookHandler(t *testing.T) {
 }
 
 func TestGetBookHandler(t *testing.T) {
-	bookObj := &book.Book{ISBN: "123", Title: "Go"}
+	b := &book.BookInfo{ID: 1, ISBN: "123", Title: "Go"}
 	uc := new(mocks.MockUsecase)
-	uc.EXPECT().Get("123").Return(bookObj, nil).Once()
+	uc.EXPECT().Get(1).Return(b, nil).Once()
 
 	h := delivery.NewHandler(uc)
-	c, rec := setupEchoConext("/books/123", nil)
-	c.SetParamNames("isbn")
-	c.SetParamValues("123")
+	c, rec := setupEchoConext("/books/1", nil)
+	c.SetParamNames("id")
+	c.SetParamValues("1")
 
 	err := h.Get(c)
 
@@ -78,12 +78,12 @@ func TestUpdateBookHandler(t *testing.T) {
 
 func TestDeleteBookHandler(t *testing.T) {
 	uc := new(mocks.MockUsecase)
-	uc.EXPECT().Delete("123", "owner1").Return(nil).Once()
+	uc.EXPECT().Delete(1, "owner1").Return(nil).Once()
 
 	h := delivery.NewHandler(uc)
-	c, rec := setupEchoConext("/books/123", nil)
-	c.SetParamNames("isbn")
-	c.SetParamValues("123")
+	c, rec := setupEchoConext("/books/1", nil)
+	c.SetParamNames("id")
+	c.SetParamValues("1")
 	c.Set("user_id", "owner1")
 
 	err := h.Delete(c)
@@ -95,8 +95,8 @@ func TestDeleteBookHandler(t *testing.T) {
 
 func TestListBooksHandler(t *testing.T) {
 	books := []*book.BookInfo{
-		{ISBN: "1", Title: "Book 1", Author: "Author 1", Year: 2021, Owner: book.BookOwner{OwnerID: "owner1"}},
-		{ISBN: "2", Title: "Book 2", Author: "Author 2", Year: 2022, Owner: book.BookOwner{OwnerID: "owner2"}},
+		{ISBN: "1", Title: "Book 1", Author: "Author 1", Year: 2021, Owner: book.BookOwner{ID: "owner1"}},
+		{ISBN: "2", Title: "Book 2", Author: "Author 2", Year: 2022, Owner: book.BookOwner{ID: "owner2"}},
 	}
 	uc := new(mocks.MockUsecase)
 	uc.EXPECT().List().Return(books, nil).Once()
@@ -113,13 +113,13 @@ func TestListBooksHandler(t *testing.T) {
 
 func TestBookHandlerErrors(t *testing.T) {
 	uc := new(mocks.MockUsecase)
-	uc.EXPECT().Get("404").Return(nil, errors.New("not found")).Once()
+	uc.EXPECT().Get(222).Return(nil, errors.New("not found")).Once()
 
 	h := delivery.NewHandler(uc)
 
-	c, _ := setupEchoConext("/books/404", nil)
-	c.SetParamNames("isbn")
-	c.SetParamValues("404")
+	c, _ := setupEchoConext("/books/222", nil)
+	c.SetParamNames("id")
+	c.SetParamValues("222")
 
 	err := h.Get(c)
 	assert.Error(t, err)

--- a/internal/book/mocks/mocks.go
+++ b/internal/book/mocks/mocks.go
@@ -37,16 +37,16 @@ func (_m *MockRepository) EXPECT() *MockRepository_Expecter {
 }
 
 // Delete provides a mock function for the type MockRepository
-func (_mock *MockRepository) Delete(isbn string) error {
-	ret := _mock.Called(isbn)
+func (_mock *MockRepository) Delete(id int) error {
+	ret := _mock.Called(id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Delete")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(isbn)
+	if returnFunc, ok := ret.Get(0).(func(int) error); ok {
+		r0 = returnFunc(id)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -59,16 +59,16 @@ type MockRepository_Delete_Call struct {
 }
 
 // Delete is a helper method to define mock.On call
-//   - isbn string
-func (_e *MockRepository_Expecter) Delete(isbn interface{}) *MockRepository_Delete_Call {
-	return &MockRepository_Delete_Call{Call: _e.mock.On("Delete", isbn)}
+//   - id int
+func (_e *MockRepository_Expecter) Delete(id interface{}) *MockRepository_Delete_Call {
+	return &MockRepository_Delete_Call{Call: _e.mock.On("Delete", id)}
 }
 
-func (_c *MockRepository_Delete_Call) Run(run func(isbn string)) *MockRepository_Delete_Call {
+func (_c *MockRepository_Delete_Call) Run(run func(id int)) *MockRepository_Delete_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 int
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(int)
 		}
 		run(
 			arg0,
@@ -82,55 +82,55 @@ func (_c *MockRepository_Delete_Call) Return(err error) *MockRepository_Delete_C
 	return _c
 }
 
-func (_c *MockRepository_Delete_Call) RunAndReturn(run func(isbn string) error) *MockRepository_Delete_Call {
+func (_c *MockRepository_Delete_Call) RunAndReturn(run func(id int) error) *MockRepository_Delete_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// FindByISBN provides a mock function for the type MockRepository
-func (_mock *MockRepository) FindByISBN(isbn string) (*book.Book, error) {
-	ret := _mock.Called(isbn)
+// FindByID provides a mock function for the type MockRepository
+func (_mock *MockRepository) FindByID(id int) (*book.BookInfo, error) {
+	ret := _mock.Called(id)
 
 	if len(ret) == 0 {
-		panic("no return value specified for FindByISBN")
+		panic("no return value specified for FindByID")
 	}
 
-	var r0 *book.Book
+	var r0 *book.BookInfo
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (*book.Book, error)); ok {
-		return returnFunc(isbn)
+	if returnFunc, ok := ret.Get(0).(func(int) (*book.BookInfo, error)); ok {
+		return returnFunc(id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *book.Book); ok {
-		r0 = returnFunc(isbn)
+	if returnFunc, ok := ret.Get(0).(func(int) *book.BookInfo); ok {
+		r0 = returnFunc(id)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*book.Book)
+			r0 = ret.Get(0).(*book.BookInfo)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(isbn)
+	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
+		r1 = returnFunc(id)
 	} else {
 		r1 = ret.Error(1)
 	}
 	return r0, r1
 }
 
-// MockRepository_FindByISBN_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindByISBN'
-type MockRepository_FindByISBN_Call struct {
+// MockRepository_FindByID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FindByID'
+type MockRepository_FindByID_Call struct {
 	*mock.Call
 }
 
-// FindByISBN is a helper method to define mock.On call
-//   - isbn string
-func (_e *MockRepository_Expecter) FindByISBN(isbn interface{}) *MockRepository_FindByISBN_Call {
-	return &MockRepository_FindByISBN_Call{Call: _e.mock.On("FindByISBN", isbn)}
+// FindByID is a helper method to define mock.On call
+//   - id int
+func (_e *MockRepository_Expecter) FindByID(id interface{}) *MockRepository_FindByID_Call {
+	return &MockRepository_FindByID_Call{Call: _e.mock.On("FindByID", id)}
 }
 
-func (_c *MockRepository_FindByISBN_Call) Run(run func(isbn string)) *MockRepository_FindByISBN_Call {
+func (_c *MockRepository_FindByID_Call) Run(run func(id int)) *MockRepository_FindByID_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 int
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(int)
 		}
 		run(
 			arg0,
@@ -139,12 +139,12 @@ func (_c *MockRepository_FindByISBN_Call) Run(run func(isbn string)) *MockReposi
 	return _c
 }
 
-func (_c *MockRepository_FindByISBN_Call) Return(book1 *book.Book, err error) *MockRepository_FindByISBN_Call {
-	_c.Call.Return(book1, err)
+func (_c *MockRepository_FindByID_Call) Return(bookInfo *book.BookInfo, err error) *MockRepository_FindByID_Call {
+	_c.Call.Return(bookInfo, err)
 	return _c
 }
 
-func (_c *MockRepository_FindByISBN_Call) RunAndReturn(run func(isbn string) (*book.Book, error)) *MockRepository_FindByISBN_Call {
+func (_c *MockRepository_FindByID_Call) RunAndReturn(run func(id int) (*book.BookInfo, error)) *MockRepository_FindByID_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -385,16 +385,16 @@ func (_c *MockUsecase_Create_Call) RunAndReturn(run func(b *book.Book) error) *M
 }
 
 // Delete provides a mock function for the type MockUsecase
-func (_mock *MockUsecase) Delete(isbn string, ownerID string) error {
-	ret := _mock.Called(isbn, ownerID)
+func (_mock *MockUsecase) Delete(id int, ownerID string) error {
+	ret := _mock.Called(id, ownerID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Delete")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, string) error); ok {
-		r0 = returnFunc(isbn, ownerID)
+	if returnFunc, ok := ret.Get(0).(func(int, string) error); ok {
+		r0 = returnFunc(id, ownerID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -407,17 +407,17 @@ type MockUsecase_Delete_Call struct {
 }
 
 // Delete is a helper method to define mock.On call
-//   - isbn string
+//   - id int
 //   - ownerID string
-func (_e *MockUsecase_Expecter) Delete(isbn interface{}, ownerID interface{}) *MockUsecase_Delete_Call {
-	return &MockUsecase_Delete_Call{Call: _e.mock.On("Delete", isbn, ownerID)}
+func (_e *MockUsecase_Expecter) Delete(id interface{}, ownerID interface{}) *MockUsecase_Delete_Call {
+	return &MockUsecase_Delete_Call{Call: _e.mock.On("Delete", id, ownerID)}
 }
 
-func (_c *MockUsecase_Delete_Call) Run(run func(isbn string, ownerID string)) *MockUsecase_Delete_Call {
+func (_c *MockUsecase_Delete_Call) Run(run func(id int, ownerID string)) *MockUsecase_Delete_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 int
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(int)
 		}
 		var arg1 string
 		if args[1] != nil {
@@ -436,33 +436,33 @@ func (_c *MockUsecase_Delete_Call) Return(err error) *MockUsecase_Delete_Call {
 	return _c
 }
 
-func (_c *MockUsecase_Delete_Call) RunAndReturn(run func(isbn string, ownerID string) error) *MockUsecase_Delete_Call {
+func (_c *MockUsecase_Delete_Call) RunAndReturn(run func(id int, ownerID string) error) *MockUsecase_Delete_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Get provides a mock function for the type MockUsecase
-func (_mock *MockUsecase) Get(isbn string) (*book.Book, error) {
-	ret := _mock.Called(isbn)
+func (_mock *MockUsecase) Get(id int) (*book.BookInfo, error) {
+	ret := _mock.Called(id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Get")
 	}
 
-	var r0 *book.Book
+	var r0 *book.BookInfo
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (*book.Book, error)); ok {
-		return returnFunc(isbn)
+	if returnFunc, ok := ret.Get(0).(func(int) (*book.BookInfo, error)); ok {
+		return returnFunc(id)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) *book.Book); ok {
-		r0 = returnFunc(isbn)
+	if returnFunc, ok := ret.Get(0).(func(int) *book.BookInfo); ok {
+		r0 = returnFunc(id)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*book.Book)
+			r0 = ret.Get(0).(*book.BookInfo)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(isbn)
+	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
+		r1 = returnFunc(id)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -475,16 +475,16 @@ type MockUsecase_Get_Call struct {
 }
 
 // Get is a helper method to define mock.On call
-//   - isbn string
-func (_e *MockUsecase_Expecter) Get(isbn interface{}) *MockUsecase_Get_Call {
-	return &MockUsecase_Get_Call{Call: _e.mock.On("Get", isbn)}
+//   - id int
+func (_e *MockUsecase_Expecter) Get(id interface{}) *MockUsecase_Get_Call {
+	return &MockUsecase_Get_Call{Call: _e.mock.On("Get", id)}
 }
 
-func (_c *MockUsecase_Get_Call) Run(run func(isbn string)) *MockUsecase_Get_Call {
+func (_c *MockUsecase_Get_Call) Run(run func(id int)) *MockUsecase_Get_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 int
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(int)
 		}
 		run(
 			arg0,
@@ -493,12 +493,12 @@ func (_c *MockUsecase_Get_Call) Run(run func(isbn string)) *MockUsecase_Get_Call
 	return _c
 }
 
-func (_c *MockUsecase_Get_Call) Return(book1 *book.Book, err error) *MockUsecase_Get_Call {
-	_c.Call.Return(book1, err)
+func (_c *MockUsecase_Get_Call) Return(bookInfo *book.BookInfo, err error) *MockUsecase_Get_Call {
+	_c.Call.Return(bookInfo, err)
 	return _c
 }
 
-func (_c *MockUsecase_Get_Call) RunAndReturn(run func(isbn string) (*book.Book, error)) *MockUsecase_Get_Call {
+func (_c *MockUsecase_Get_Call) RunAndReturn(run func(id int) (*book.BookInfo, error)) *MockUsecase_Get_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/book/repository/repository_test.go
+++ b/internal/book/repository/repository_test.go
@@ -23,8 +23,8 @@ func TestBookRepository(t *testing.T) {
 	assert.NoError(t, db.Error)
 
 	t.Run("should save and find book by ISBN", func(t *testing.T) {
-
 		b := &book.Book{
+			ID:          1,
 			OwnerID:     ownerID,
 			ISBN:        "isbn-001",
 			Title:       "Book Title",
@@ -36,13 +36,14 @@ func TestBookRepository(t *testing.T) {
 		err := r.Save(b)
 		assert.NoError(t, err)
 
-		found, err := r.FindByISBN("isbn-001")
+		found, err := r.FindByID(1)
 		assert.NoError(t, err)
-		assertBookEqual(t, b, found)
+		assertBookInfo(t, b, found)
 	})
 
 	t.Run("should update book", func(t *testing.T) {
 		b := &book.Book{
+			ID:          1,
 			OwnerID:     ownerID,
 			ISBN:        "isbn-001",
 			Title:       "Updated Title",
@@ -54,9 +55,9 @@ func TestBookRepository(t *testing.T) {
 		err := r.Update(b)
 		assert.NoError(t, err)
 
-		found, err := r.FindByISBN("isbn-001")
+		found, err := r.FindByID(1)
 		assert.NoError(t, err)
-		assertBookEqual(t, b, found)
+		assertBookInfo(t, b, found)
 	})
 
 	t.Run("should list books", func(t *testing.T) {
@@ -65,40 +66,37 @@ func TestBookRepository(t *testing.T) {
 		assert.True(t, len(books) >= 1)
 
 		// Check that the returned BookInfo matches the inserted book
-		found := false
 		for _, info := range books {
 			if info.ISBN == "isbn-001" {
-				found = true
 				assert.Equal(t, "Updated Title", info.Title)
 				assert.Equal(t, "Updated description", info.Description)
 				assert.Equal(t, "Updated review", info.BriefReview)
 				assert.Equal(t, "Updated Author", info.Author)
 				assert.Equal(t, 2025, info.Year)
-				assert.Equal(t, ownerID, info.Owner.OwnerID)
+				assert.Equal(t, ownerID, info.Owner.ID)
 			}
 		}
-		assert.True(t, found, "inserted book should be in the list")
 	})
 
 	t.Run("should delete book", func(t *testing.T) {
-		err := r.Delete("isbn-001")
+		err := r.Delete(1)
 		assert.NoError(t, err)
 
-		found, err := r.FindByISBN("isbn-001")
+		found, err := r.FindByID(1)
 		assert.NoError(t, err)
 		assert.Nil(t, found)
 	})
 
 	t.Run("should return nil if not found", func(t *testing.T) {
-		found, err := r.FindByISBN("not-exist")
+		found, err := r.FindByID(999)
 		assert.NoError(t, err)
 		assert.Nil(t, found)
 	})
 }
 
-func assertBookEqual(t *testing.T, expected, actual *book.Book) {
+func assertBookInfo(t *testing.T, expected *book.Book, actual *book.BookInfo) {
 	assert.NotNil(t, actual)
-	assert.Equal(t, expected.OwnerID, actual.OwnerID)
+	assert.Equal(t, expected.OwnerID, actual.Owner.ID)
 	assert.Equal(t, expected.ISBN, actual.ISBN)
 	assert.Equal(t, expected.Title, actual.Title)
 	assert.Equal(t, expected.Description, actual.Description)

--- a/internal/book/repository/schemas.go
+++ b/internal/book/repository/schemas.go
@@ -41,3 +41,14 @@ func BookSchemaToDomain(s *BookSchema) *book.Book {
 		Year:        s.Year,
 	}
 }
+
+type BookInfoResult struct {
+	ISBN        string
+	Title       string
+	Description string
+	BriefReview string
+	Author      string
+	Year        int
+	OwnerID     string
+	Username    string
+}

--- a/internal/book/usecases/interfaces.go
+++ b/internal/book/usecases/interfaces.go
@@ -4,16 +4,16 @@ import "github.com/ngoctrng/bookz/internal/book"
 
 type Repository interface {
 	Save(b *book.Book) error
-	FindByISBN(isbn string) (*book.Book, error)
+	FindByID(id int) (*book.BookInfo, error)
 	Update(b *book.Book) error
-	Delete(isbn string) error
+	Delete(id int) error
 	List() ([]*book.BookInfo, error)
 }
 
 type Usecase interface {
 	Create(b *book.Book) error
-	Get(isbn string) (*book.Book, error)
+	Get(id int) (*book.BookInfo, error)
 	Update(b *book.Book, ownerID string) error
-	Delete(isbn, ownerID string) error
+	Delete(id int, ownerID string) error
 	List() ([]*book.BookInfo, error)
 }

--- a/internal/book/usecases/services.go
+++ b/internal/book/usecases/services.go
@@ -18,34 +18,34 @@ func (s *Service) Create(b *book.Book) error {
 	return s.repo.Save(b)
 }
 
-func (s *Service) Get(isbn string) (*book.Book, error) {
-	return s.repo.FindByISBN(isbn)
+func (s *Service) Get(id int) (*book.BookInfo, error) {
+	return s.repo.FindByID(id)
 }
 
 func (s *Service) Update(b *book.Book, ownerID string) error {
-	existed, err := s.repo.FindByISBN(b.ISBN)
+	existed, err := s.repo.FindByID(b.ID)
 	if err != nil {
 		return err
 	}
 
-	if existed.OwnerID != ownerID {
+	if existed.Owner.ID != ownerID {
 		return errors.New("you do not have permission to update this book")
 	}
 
 	return s.repo.Update(b)
 }
 
-func (s *Service) Delete(isbn, ownerID string) error {
-	b, err := s.repo.FindByISBN(isbn)
+func (s *Service) Delete(id int, ownerID string) error {
+	b, err := s.repo.FindByID(id)
 	if err != nil {
 		return err
 	}
 
-	if b.OwnerID != ownerID {
+	if b.Owner.ID != ownerID {
 		return errors.New("you do not have permission to delete this book")
 	}
 
-	return s.repo.Delete(isbn)
+	return s.repo.Delete(id)
 }
 
 func (s *Service) List() ([]*book.BookInfo, error) {

--- a/internal/book/usecases/services_test.go
+++ b/internal/book/usecases/services_test.go
@@ -37,21 +37,21 @@ func TestCreateBook(t *testing.T) {
 }
 
 func TestGetBook(t *testing.T) {
-	b := &book.Book{ISBN: "isbn-001", Title: "Book Title"}
+	b := &book.BookInfo{ID: 1, ISBN: "isbn-001", Title: "Book Title"}
 	r := new(mocks.MockRepository)
 	svc := usecases.NewService(r)
 
-	t.Run("should get book by isbn", func(t *testing.T) {
-		r.EXPECT().FindByISBN("isbn-001").Return(b, nil).Once()
-		got, err := svc.Get("isbn-001")
+	t.Run("should get book by id", func(t *testing.T) {
+		r.EXPECT().FindByID(1).Return(b, nil).Once()
+		got, err := svc.Get(1)
 		assert.NoError(t, err)
 		assert.Equal(t, b, got)
 		r.AssertExpectations(t)
 	})
 
 	t.Run("should return error if repo fails", func(t *testing.T) {
-		r.EXPECT().FindByISBN("isbn-001").Return(nil, errors.New("db error")).Once()
-		got, err := svc.Get("isbn-001")
+		r.EXPECT().FindByID(1).Return(nil, errors.New("db error")).Once()
+		got, err := svc.Get(1)
 		assert.Error(t, err)
 		assert.Nil(t, got)
 		r.AssertExpectations(t)
@@ -59,12 +59,14 @@ func TestGetBook(t *testing.T) {
 }
 
 func TestUpdateBook(t *testing.T) {
-	origin := &book.Book{
-		OwnerID: "owner1",
-		ISBN:    "isbn-001",
-		Title:   "Old Title",
+	origin := &book.BookInfo{
+		ID:    1,
+		Owner: book.BookOwner{ID: "owner1"},
+		ISBN:  "isbn-001",
+		Title: "Old Title",
 	}
 	updated := &book.Book{
+		ID:      1,
 		OwnerID: "owner1",
 		ISBN:    "isbn-001",
 		Title:   "New Title",
@@ -73,7 +75,7 @@ func TestUpdateBook(t *testing.T) {
 	svc := usecases.NewService(r)
 
 	t.Run("should update book if owner matches", func(t *testing.T) {
-		r.EXPECT().FindByISBN("isbn-001").Return(origin, nil).Once()
+		r.EXPECT().FindByID(1).Return(origin, nil).Once()
 		r.EXPECT().Update(updated).Return(nil).Once()
 		err := svc.Update(updated, "owner1")
 		assert.NoError(t, err)
@@ -81,7 +83,7 @@ func TestUpdateBook(t *testing.T) {
 	})
 
 	t.Run("should not update if owner does not match", func(t *testing.T) {
-		r.EXPECT().FindByISBN("isbn-001").Return(origin, nil).Once()
+		r.EXPECT().FindByID(1).Return(origin, nil).Once()
 		err := svc.Update(updated, "other-owner")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "permission")
@@ -89,7 +91,7 @@ func TestUpdateBook(t *testing.T) {
 	})
 
 	t.Run("should return error if repo fails", func(t *testing.T) {
-		r.EXPECT().FindByISBN("isbn-001").Return(nil, errors.New("db error")).Once()
+		r.EXPECT().FindByID(1).Return(nil, errors.New("db error")).Once()
 		err := svc.Update(updated, "owner1")
 		assert.Error(t, err)
 		r.AssertExpectations(t)
@@ -97,33 +99,34 @@ func TestUpdateBook(t *testing.T) {
 }
 
 func TestDeleteBook(t *testing.T) {
-	b := &book.Book{
-		OwnerID: "owner1",
-		ISBN:    "isbn-001",
-		Title:   "Book Title",
+	b := &book.BookInfo{
+		ID:    1,
+		Owner: book.BookOwner{ID: "owner1"},
+		ISBN:  "isbn-001",
+		Title: "Book Title",
 	}
 	r := new(mocks.MockRepository)
 	svc := usecases.NewService(r)
 
 	t.Run("should delete book if owner matches", func(t *testing.T) {
-		r.EXPECT().FindByISBN("isbn-001").Return(b, nil).Once()
-		r.EXPECT().Delete("isbn-001").Return(nil).Once()
-		err := svc.Delete("isbn-001", "owner1")
+		r.EXPECT().FindByID(1).Return(b, nil).Once()
+		r.EXPECT().Delete(1).Return(nil).Once()
+		err := svc.Delete(1, "owner1")
 		assert.NoError(t, err)
 		r.AssertExpectations(t)
 	})
 
 	t.Run("should not delete if owner does not match", func(t *testing.T) {
-		r.EXPECT().FindByISBN("isbn-001").Return(b, nil).Once()
-		err := svc.Delete("isbn-001", "other-owner")
+		r.EXPECT().FindByID(1).Return(b, nil).Once()
+		err := svc.Delete(1, "other-owner")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "permission")
 		r.AssertExpectations(t)
 	})
 
 	t.Run("should return error if repo fails", func(t *testing.T) {
-		r.EXPECT().FindByISBN("isbn-001").Return(nil, errors.New("db error")).Once()
-		err := svc.Delete("isbn-001", "owner1")
+		r.EXPECT().FindByID(1).Return(nil, errors.New("db error")).Once()
+		err := svc.Delete(1, "owner1")
 		assert.Error(t, err)
 		r.AssertExpectations(t)
 	})
@@ -131,8 +134,8 @@ func TestDeleteBook(t *testing.T) {
 
 func TestListBooks(t *testing.T) {
 	books := []*book.BookInfo{
-		{ISBN: "1", Title: "Book 1", Author: "Author 1", Year: 2021, Owner: book.BookOwner{OwnerID: "owner1"}},
-		{ISBN: "2", Title: "Book 2", Author: "Author 2", Year: 2022, Owner: book.BookOwner{OwnerID: "owner2"}},
+		{ID: 1, ISBN: "1", Title: "Book 1", Author: "Author 1", Year: 2021, Owner: book.BookOwner{ID: "owner1"}},
+		{ID: 2, ISBN: "2", Title: "Book 2", Author: "Author 2", Year: 2022, Owner: book.BookOwner{ID: "owner2"}},
 	}
 	r := new(mocks.MockRepository)
 	svc := usecases.NewService(r)

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -31,7 +31,7 @@ func New(cfg *config.Config, db *gorm.DB) *Server {
 	publicRoutes := [][]string{
 		{"POST", "/api/account/register"},
 		{"POST", "/api/account/login"},
-		{"GET", "/api/books/:isbn"},
+		{"GET", "/api/books/:id"},
 		{"GET", "/api/books"},
 		{"GET", "/health"},
 	}
@@ -57,13 +57,13 @@ func New(cfg *config.Config, db *gorm.DB) *Server {
 	public := api.Group("")
 	public.POST("/account/register", accountHandlers.Register)
 	public.POST("/account/login", accountHandlers.Login)
-	public.GET("/books/:isbn", bookHandlers.Get)
+	public.GET("/books/:id", bookHandlers.Get)
 	public.GET("/books", bookHandlers.List)
 
 	// private routes
 	api.POST("/books", bookHandlers.Create)
-	api.PUT("/books/:isbn", bookHandlers.Update)
-	api.DELETE("/books/:isbn", bookHandlers.Delete)
+	api.PUT("/books/:id", bookHandlers.Update)
+	api.DELETE("/books/:id", bookHandlers.Delete)
 
 	return &Server{echo: e, cfg: cfg}
 }

--- a/pkg/migration/migrations/20250625011245-create-books-table.sql
+++ b/pkg/migration/migrations/20250625011245-create-books-table.sql
@@ -1,7 +1,8 @@
 
 -- +migrate Up
 CREATE TABLE IF NOT EXISTS books (
-    isbn          VARCHAR(64) PRIMARY KEY,
+    id            SERIAL PRIMARY KEY,
+    isbn          VARCHAR(64) NOT NULL,
     owner_id      uuid NOT NULL,
     title         VARCHAR(255) NOT NULL,
     description   TEXT,


### PR DESCRIPTION

<!-- octocov -->
## Code Metrics Report
| Coverage | Code to Test Ratio | Test Execution Time |
|---------:|-------------------:|--------------------:|
| 61.4%    | 1:0.5              | 18s                 |


### Code coverage of files in pull request scope (49.2%)

|                                                                                 Files                                                                                  | Coverage |
|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|
| [internal/book/book.go](https://github.com/ngoctrng/bookz/blob/e0095d601a6575f33b06304fe230340be9be992f/internal%2Fbook%2Fbook.go)                                     | 0.0%     |
| [internal/book/delivery/handlers.go](https://github.com/ngoctrng/bookz/blob/e0095d601a6575f33b06304fe230340be9be992f/internal%2Fbook%2Fdelivery%2Fhandlers.go)         | 78.3%    |
| [internal/book/repository/repository.go](https://github.com/ngoctrng/bookz/blob/e0095d601a6575f33b06304fe230340be9be992f/internal%2Fbook%2Frepository%2Frepository.go) | 90.4%    |
| [internal/book/repository/schemas.go](https://github.com/ngoctrng/bookz/blob/e0095d601a6575f33b06304fe230340be9be992f/internal%2Fbook%2Frepository%2Fschemas.go)       | 50.0%    |
| [internal/book/usecases/services.go](https://github.com/ngoctrng/bookz/blob/e0095d601a6575f33b06304fe230340be9be992f/internal%2Fbook%2Fusecases%2Fservices.go)         | 100.0%   |
| [internal/httpserver/server.go](https://github.com/ngoctrng/bookz/blob/e0095d601a6575f33b06304fe230340be9be992f/internal%2Fhttpserver%2Fserver.go)                     | 0.0%     |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
