### PR TITLE
feat: accept proposal

### DIFF
--- a/internal/exchange/delivery/handlers.go
+++ b/internal/exchange/delivery/handlers.go
@@ -75,3 +75,19 @@ func (h *Handler) GetAllProposals(c echo.Context) error {
 	}
 	return c.JSON(http.StatusOK, proposals)
 }
+
+func (h *Handler) AcceptProposal(c echo.Context) error {
+	id, _ := strconv.Atoi(c.Param("id"))
+	userID := c.Get("user_id").(string)
+
+	uid, err := uuid.Parse(userID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "invalid user_id")
+	}
+
+	if err := h.uc.AcceptProposal(id, uid); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	return c.NoContent(http.StatusOK)
+}

--- a/internal/exchange/mocks/mocks.go
+++ b/internal/exchange/mocks/mocks.go
@@ -38,6 +38,68 @@ func (_m *MockRepository) EXPECT() *MockRepository_Expecter {
 	return &MockRepository_Expecter{mock: &_m.Mock}
 }
 
+// FetchRequestedBookOwner provides a mock function for the type MockRepository
+func (_mock *MockRepository) FetchRequestedBookOwner(id int) (uuid.UUID, error) {
+	ret := _mock.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for FetchRequestedBookOwner")
+	}
+
+	var r0 uuid.UUID
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(int) (uuid.UUID, error)); ok {
+		return returnFunc(id)
+	}
+	if returnFunc, ok := ret.Get(0).(func(int) uuid.UUID); ok {
+		r0 = returnFunc(id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(uuid.UUID)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(int) error); ok {
+		r1 = returnFunc(id)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockRepository_FetchRequestedBookOwner_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'FetchRequestedBookOwner'
+type MockRepository_FetchRequestedBookOwner_Call struct {
+	*mock.Call
+}
+
+// FetchRequestedBookOwner is a helper method to define mock.On call
+//   - id int
+func (_e *MockRepository_Expecter) FetchRequestedBookOwner(id interface{}) *MockRepository_FetchRequestedBookOwner_Call {
+	return &MockRepository_FetchRequestedBookOwner_Call{Call: _e.mock.On("FetchRequestedBookOwner", id)}
+}
+
+func (_c *MockRepository_FetchRequestedBookOwner_Call) Run(run func(id int)) *MockRepository_FetchRequestedBookOwner_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockRepository_FetchRequestedBookOwner_Call) Return(uUID uuid.UUID, err error) *MockRepository_FetchRequestedBookOwner_Call {
+	_c.Call.Return(uUID, err)
+	return _c
+}
+
+func (_c *MockRepository_FetchRequestedBookOwner_Call) RunAndReturn(run func(id int) (uuid.UUID, error)) *MockRepository_FetchRequestedBookOwner_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAll provides a mock function for the type MockRepository
 func (_mock *MockRepository) GetAll(uid uuid.UUID) ([]*exchange.Proposal, error) {
 	ret := _mock.Called(uid)
@@ -238,6 +300,63 @@ type MockUsecase_Expecter struct {
 
 func (_m *MockUsecase) EXPECT() *MockUsecase_Expecter {
 	return &MockUsecase_Expecter{mock: &_m.Mock}
+}
+
+// AcceptProposal provides a mock function for the type MockUsecase
+func (_mock *MockUsecase) AcceptProposal(id int, uid uuid.UUID) error {
+	ret := _mock.Called(id, uid)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AcceptProposal")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(int, uuid.UUID) error); ok {
+		r0 = returnFunc(id, uid)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockUsecase_AcceptProposal_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AcceptProposal'
+type MockUsecase_AcceptProposal_Call struct {
+	*mock.Call
+}
+
+// AcceptProposal is a helper method to define mock.On call
+//   - id int
+//   - uid uuid.UUID
+func (_e *MockUsecase_Expecter) AcceptProposal(id interface{}, uid interface{}) *MockUsecase_AcceptProposal_Call {
+	return &MockUsecase_AcceptProposal_Call{Call: _e.mock.On("AcceptProposal", id, uid)}
+}
+
+func (_c *MockUsecase_AcceptProposal_Call) Run(run func(id int, uid uuid.UUID)) *MockUsecase_AcceptProposal_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 int
+		if args[0] != nil {
+			arg0 = args[0].(int)
+		}
+		var arg1 uuid.UUID
+		if args[1] != nil {
+			arg1 = args[1].(uuid.UUID)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockUsecase_AcceptProposal_Call) Return(err error) *MockUsecase_AcceptProposal_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockUsecase_AcceptProposal_Call) RunAndReturn(run func(id int, uid uuid.UUID) error) *MockUsecase_AcceptProposal_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // CreateProposal provides a mock function for the type MockUsecase

--- a/internal/exchange/proposal.go
+++ b/internal/exchange/proposal.go
@@ -23,6 +23,7 @@ type Proposal struct {
 	Status        RequestStatus
 	RequestedAt   time.Time
 	RequestBy     uuid.UUID
+	RequestTo     uuid.UUID // Owner of the requested book
 }
 
 func OpenProposal(by uuid.UUID, requested BookID, forExchangeID BookID) *Proposal {
@@ -37,6 +38,10 @@ func OpenProposal(by uuid.UUID, requested BookID, forExchangeID BookID) *Proposa
 
 func (p *Proposal) AddMessage(message string) {
 	p.Message = message
+}
+
+func (p *Proposal) SendRequestTo(owner uuid.UUID) {
+	p.RequestTo = owner
 }
 
 func (p *Proposal) Accept() {

--- a/internal/exchange/repository/schemas.go
+++ b/internal/exchange/repository/schemas.go
@@ -11,6 +11,7 @@ import (
 type ProposalSchema struct {
 	ID            int
 	RequestBy     uuid.UUID
+	RequestTo     uuid.UUID
 	RequestedID   int
 	ForExchangeID int
 	Message       string
@@ -24,6 +25,7 @@ func DomainToProposalSchema(p *exchange.Proposal) *ProposalSchema {
 	return &ProposalSchema{
 		ID:            p.ID,
 		RequestBy:     p.RequestBy,
+		RequestTo:     p.RequestTo,
 		RequestedID:   int(p.RequestedID),
 		ForExchangeID: int(p.ForExchangeID),
 		Message:       p.Message,
@@ -36,6 +38,7 @@ func ProposalSchemaToDomain(s *ProposalSchema) *exchange.Proposal {
 	return &exchange.Proposal{
 		ID:            s.ID,
 		RequestBy:     s.RequestBy,
+		RequestTo:     s.RequestTo,
 		RequestedID:   exchange.BookID(s.RequestedID),
 		ForExchangeID: exchange.BookID(s.ForExchangeID),
 		Message:       s.Message,

--- a/internal/exchange/usecases/interfaces.go
+++ b/internal/exchange/usecases/interfaces.go
@@ -9,12 +9,14 @@ type Repository interface {
 	Save(p *exchange.Proposal) error
 	GetByID(id int) (*exchange.Proposal, error)
 	GetAll(uid uuid.UUID) ([]*exchange.Proposal, error)
+	FetchRequestedBookOwner(id int) (uuid.UUID, error)
 }
 
 type Usecase interface {
 	CreateProposal(in CreateProposalInput) error
 	GetProposalByID(id int) (*exchange.Proposal, error)
 	GetAllProposals(uid uuid.UUID) ([]*exchange.Proposal, error)
+	AcceptProposal(id int, uid uuid.UUID) error
 }
 
 type CreateProposalInput struct {

--- a/internal/exchange/usecases/services_test.go
+++ b/internal/exchange/usecases/services_test.go
@@ -27,6 +27,7 @@ func TestCreateProposal(t *testing.T) {
 
 	t.Run("should create proposal successfully", func(t *testing.T) {
 		r.EXPECT().Save(mock.AnythingOfType("*exchange.Proposal")).Return(nil).Once()
+		r.EXPECT().FetchRequestedBookOwner(int(input.Requested)).Return(uuid.New(), nil).Once()
 		err := svc.CreateProposal(input)
 		assert.NoError(t, err)
 		r.AssertExpectations(t)
@@ -34,6 +35,7 @@ func TestCreateProposal(t *testing.T) {
 
 	t.Run("should return error if repo fails", func(t *testing.T) {
 		r.EXPECT().Save(mock.AnythingOfType("*exchange.Proposal")).Return(errors.New("db error")).Once()
+		r.EXPECT().FetchRequestedBookOwner(int(input.Requested)).Return(uuid.New(), nil).Once()
 		err := svc.CreateProposal(input)
 		assert.Error(t, err)
 		r.AssertExpectations(t)

--- a/internal/httpserver/server.go
+++ b/internal/httpserver/server.go
@@ -71,6 +71,7 @@ func New(cfg *config.Config, db *gorm.DB) *Server {
 	api.POST("/exchange/proposals", exchangeHandlers.CreateProposal)
 	api.GET("/exchange/proposals/:id", exchangeHandlers.GetProposalByID)
 	api.GET("/exchange/proposals", exchangeHandlers.GetAllProposals)
+	api.PUT("/exchange/proposals/:id/accept", exchangeHandlers.AcceptProposal)
 
 	return &Server{echo: e, cfg: cfg}
 }

--- a/pkg/migration/migrations/20250626022657-create-proposals-table.sql
+++ b/pkg/migration/migrations/20250626022657-create-proposals-table.sql
@@ -3,6 +3,7 @@
 CREATE TABLE proposals (
     id              SERIAL PRIMARY KEY,
     request_by      UUID        NOT NULL,
+    request_to      UUID        NOT NULL,
     requested_id    INTEGER     NOT NULL,
     for_exchange_id INTEGER     NOT NULL,
     message         TEXT,


### PR DESCRIPTION

<!-- octocov -->
## Code Metrics Report
|                         | [master](https://github.com/ngoctrng/bookz/tree/master) ([29da2bb](https://github.com/ngoctrng/bookz/commit/29da2bb01d201966205ee564628db5e5e5c2216b)) | [#8](https://github.com/ngoctrng/bookz/pull/8) ([c8501b6](https://github.com/ngoctrng/bookz/commit/c8501b642cda526d0950f463564598c0b2c48640)) |  +/-  |
|-------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------:|----------------------------------------------------------------------------------------------------------------------------------------------:|------:|
| **Coverage**            |                                                                                                                                                  65.8% |                                                                                                                                         62.9% | -2.9% |
| **Code to Test Ratio**  |                                                                                                                                                  1:0.5 |                                                                                                                                         1:0.4 |  -0.1 |
| **Test Execution Time** |                                                                                                                                                    48s |                                                                                                                                           17s |  -31s |

<details>

<summary>Details</summary>

``` diff
  |                     | master (29da2bb) | #8 (c8501b6) |  +/-  |
  |---------------------|------------------|--------------|-------|
- | Coverage            |            65.8% |        62.9% | -2.9% |
  |   Files             |               25 |           25 |     0 |
  |   Lines             |              322 |          354 |   +32 |
+ |   Covered           |              212 |          223 |   +11 |
- | Code to Test Ratio  |            1:0.5 |        1:0.4 |  -0.1 |
  |   Code              |             2192 |         2351 |  +159 |
+ |   Test              |             1141 |         1167 |   +26 |
+ | Test Execution Time |              48s |          17s |  -31s |
```

</details>


### Code coverage of files in pull request scope (46.9% → 44.4%)

|                                                                                     Files                                                                                      | Coverage |  +/-   |  Status  |
|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|-------:|---------:|
| [internal/exchange/delivery/handlers.go](https://github.com/ngoctrng/bookz/blob/11dcf83474111fe9da2a81a981f32fbe3ada5788/internal%2Fexchange%2Fdelivery%2Fhandlers.go)         | 68.4%    | -18.3% | modified |
| [internal/exchange/proposal.go](https://github.com/ngoctrng/bookz/blob/11dcf83474111fe9da2a81a981f32fbe3ada5788/internal%2Fexchange%2Fproposal.go)                             | 33.3%    | -6.7%  | modified |
| [internal/exchange/repository/repository.go](https://github.com/ngoctrng/bookz/blob/11dcf83474111fe9da2a81a981f32fbe3ada5788/internal%2Fexchange%2Frepository%2Frepository.go) | 88.8%    | 0.0%   | modified |
| [internal/exchange/repository/schemas.go](https://github.com/ngoctrng/bookz/blob/11dcf83474111fe9da2a81a981f32fbe3ada5788/internal%2Fexchange%2Frepository%2Fschemas.go)       | 100.0%   | 0.0%   | modified |
| [internal/exchange/usecases/services.go](https://github.com/ngoctrng/bookz/blob/11dcf83474111fe9da2a81a981f32fbe3ada5788/internal%2Fexchange%2Fusecases%2Fservices.go)         | 64.2%    | -35.8% | modified |
| [internal/httpserver/server.go](https://github.com/ngoctrng/bookz/blob/11dcf83474111fe9da2a81a981f32fbe3ada5788/internal%2Fhttpserver%2Fserver.go)                             | 0.0%     | 0.0%   | modified |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
